### PR TITLE
add tests for recapitalizePoolByStackedZun & restoreStakedZunByRewards

### DIFF
--- a/contracts/test/StubRewardToZunManager.sol
+++ b/contracts/test/StubRewardToZunManager.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import { IRewardManager } from '../interfaces/IRewardManager.sol';
+import { IERC20 } from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import { SafeERC20 } from '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
+
+/**
+ * @title StubZunRewardManager contract
+ * @notice Stub implementation of reward manager for converting from `reward` to `ZUN_TOKEN`
+ */
+contract StubRewardToZunManager is IRewardManager {
+    using SafeERC20 for IERC20;
+
+    IERC20 public immutable ZUN_TOKEN;
+    address public immutable ZUN_TOKEN_HOLDER;
+
+    constructor(IERC20 _zunToken, address _zunTokenHolder) {
+        if (address(0) == address(_zunToken)) revert('Zero address');
+        ZUN_TOKEN = _zunToken;
+        ZUN_TOKEN_HOLDER = _zunTokenHolder;
+    }
+
+    /**
+     * @dev Transfer provided `_amount` of ZUN tokens to `msg.sender` (1:1 converting)
+     * Need to approve required `_amount` from `ZUN_TOKEN_HOLDER` during testing
+     */
+    function handle(address, uint256 _amount, address _receivingToken) external override {
+        if (_receivingToken != address(ZUN_TOKEN)) revert('Receiving token should be zun token');
+        IERC20(_receivingToken).safeTransferFrom(ZUN_TOKEN_HOLDER, address(msg.sender), _amount);
+    }
+
+    function valuate(
+        address,
+        uint256 _amount,
+        address _receivingToken
+    ) external view override returns (uint256) {
+        if (_receivingToken != address(ZUN_TOKEN)) revert('Receiving token should be zun token');
+        return _amount;
+    }
+}

--- a/contracts/test/StubZunToDAITokenManager.sol
+++ b/contracts/test/StubZunToDAITokenManager.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import { IRewardManager } from '../interfaces/IRewardManager.sol';
+import { IERC20 } from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import { SafeERC20 } from '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
+import { Constants } from '../utils/Constants.sol';
+
+/**
+ * @title StubZunToRewardManager contract
+ * @notice Stub implementation of reward manager for converting from `ZUN_TOKEN` to `reward`
+ */
+contract StubZunToDAITokenManager is IRewardManager {
+    using SafeERC20 for IERC20;
+
+    IERC20 public immutable ZUN_TOKEN;
+    address public immutable SPONSOR;
+
+    constructor(IERC20 _zunToken, address _sponsor) {
+        if (address(0) == address(_zunToken)) revert('Zero address');
+        ZUN_TOKEN = _zunToken;
+        SPONSOR = _sponsor;
+    }
+
+    /**
+     * @dev Transfer provided `_amount` of `_reward` tokens to `msg.sender` (1:1 converting)
+     * Need to impersonate account to transfer `_reward` tokens approve required `_amount` during testing
+     */
+    function handle(address _reward, uint256 _amount, address _receivingToken) external override {
+        if (_reward != address(ZUN_TOKEN)) revert('Reward should be zun token');
+        if (_receivingToken != Constants.DAI_ADDRESS) revert('Receiving token should be DAI');
+        IERC20(_receivingToken).safeTransferFrom(SPONSOR, address(msg.sender), _amount);
+    }
+
+    function valuate(
+        address _reward,
+        uint256 _amount,
+        address _receivingToken
+    ) external view override returns (uint256) {
+        if (_reward != address(ZUN_TOKEN)) revert('Reward should be zun token');
+        if (_receivingToken != Constants.DAI_ADDRESS) revert('Receiving token should be DAI');
+        return _amount;
+    }
+}

--- a/contracts/tokenomics/staking/StakingRewardDistributor.sol
+++ b/contracts/tokenomics/staking/StakingRewardDistributor.sol
@@ -109,6 +109,8 @@ contract StakingRewardDistributor is
         uint256 amountAdjusted
     );
     event EarlyExitReceiverChanged(address receiver);
+    event WithdrawnPoolToken(address token, uint256 amount);
+    event ReturnedPoolToken(address token, uint256 amount);
 
     function initialize() public initializer {
         __UUPSUpgradeable_init();
@@ -246,6 +248,8 @@ contract StakingRewardDistributor is
         if (amount >= totalAmounts[pid] - recapitalizedAmounts[pid]) revert WrongAmount();
         recapitalizedAmounts[pid] += amount;
         poolInfo_.token.safeTransfer(msg.sender, amount);
+
+        emit WithdrawnPoolToken(token, amount);
     }
 
     function returnPoolToken(
@@ -257,6 +261,8 @@ contract StakingRewardDistributor is
         if (amount > recapitalizedAmounts[pid]) revert WrongAmount();
         recapitalizedAmounts[pid] -= amount;
         poolInfo_.token.safeTransferFrom(msg.sender, address(this), amount);
+
+        emit ReturnedPoolToken(token, amount);
     }
 
     // Start 2 week per block distribution for stakers

--- a/contracts/utils/Constants.sol
+++ b/contracts/utils/Constants.sol
@@ -17,7 +17,8 @@ library Constants {
     // Will be added after deployment of zunUSD v2 pool
     address internal constant zunUSD_ADDRESS = 0x8C0D76C9B18779665475F3E212D9Ca1Ed6A1A0e6;
     // Will be added after deployment of zunUSD v2 pool controller
-    address internal constant zunUSD_CONTROLLER_ADDRESS = 0x618eee502CDF6b46A2199C21D1411f3F6065c940;
+    address internal constant zunUSD_CONTROLLER_ADDRESS =
+        0x618eee502CDF6b46A2199C21D1411f3F6065c940;
     // Will be added after deployment of zunETH v2 pool
     address internal constant zunETH_ADDRESS = address(0);
 

--- a/scripts/prod/deployZunUSD.js
+++ b/scripts/prod/deployZunUSD.js
@@ -37,7 +37,9 @@ async function main() {
     console.log('Deploy StableConverter:');
     const StableConverterFactory = await ethers.getContractFactory('StableConverter');
     // const stableConverter = await StableConverterFactory.deploy();
-    const stableConverter = await StableConverterFactory.attach("0x0236B7A3996d8c3597173aA95fD2a915c7A8A42E");
+    const stableConverter = await StableConverterFactory.attach(
+        '0x0236B7A3996d8c3597173aA95fD2a915c7A8A42E'
+    );
     // await stableConverter.deployed();
     console.log('StableConverter:', stableConverter.address);
 

--- a/test/integration/RecapitalizationManager.ts
+++ b/test/integration/RecapitalizationManager.ts
@@ -28,13 +28,15 @@ import { createAndInitConicOracles } from '../utils/CreateAndInitConicOracles';
 import { createPoolAndControllerZunUSD } from '../utils/CreatePoolAndControllerZunUSD';
 import { getMinAmountZunUSD } from '../utils/GetMinAmountZunUSD';
 
-const parseZUN = (token: number) => BigNumber.from(token).mul(BigNumber.from(10).pow(18));
-
 const CVX_SPONSOR = '0x3026BDf87ffc13533C862Ec0FA3EdAf34E02AE90';
 const CRV_SPONSOR = '0x0E33Be39B13c576ff48E14392fBf96b02F40Cd34';
 const FXS_SPONSOR = '0xb744bEA7E6892c380B781151554C7eBCc764910b';
 const SDT_SPONSOR = '0xAced00E50cb81377495ea40A1A44005fe6d2482d';
 const SPELL_SPONSOR = '0x8C54EbDD960056d2CfF5998df5695dACA1FC0190';
+const DAI_SPONSOR = '0x60FaAe176336dAb62e284Fe19B885B095d29fB7F';
+
+const parseDAI = (token: number) => BigNumber.from(token).mul(BigNumber.from(10).pow(18));
+const parseZUN = (token: number) => BigNumber.from(token).mul(BigNumber.from(10).pow(18));
 
 describe('Recapitalization Manager', async () => {
     async function deployFixture() {
@@ -68,6 +70,7 @@ describe('Recapitalization Manager', async () => {
         await stakingRewardDistributor.addRewardToken(addresses.crypto.cvx);
         await stakingRewardDistributor.addRewardToken(addresses.crypto.fxs);
         await stakingRewardDistributor.addRewardToken(addresses.crypto.sdt);
+        await stakingRewardDistributor.addRewardToken(ZUN.address);
 
         // deploy recapitalization manager
         const RecapitalizationManager = await ethers.getContractFactory('RecapitalizationManager');
@@ -81,12 +84,17 @@ describe('Recapitalization Manager', async () => {
             addresses.crypto.cvx,
             addresses.crypto.fxs,
             addresses.crypto.sdt,
+            ZUN.address,
         ];
         await recapitalizationManager.setRewardTokens(rewards);
         await recapitalizationManager.setRewardDistributor(stakingRewardDistributor.address);
 
         await stakingRewardDistributor.grantRole(
             stakingRewardDistributor.DISTRIBUTOR_ROLE(),
+            recapitalizationManager.address
+        );
+        await stakingRewardDistributor.grantRole(
+            stakingRewardDistributor.RECAPITALIZATION_ROLE(),
             recapitalizationManager.address
         );
 
@@ -96,6 +104,7 @@ describe('Recapitalization Manager', async () => {
         const FXS = (await ethers.getContractAt('IERC20', addresses.crypto.fxs)) as IERC20;
         const SDT = (await ethers.getContractAt('IERC20', addresses.crypto.sdt)) as IERC20;
         const SPELL = (await ethers.getContractAt('IERC20', addresses.crypto.spell)) as IERC20;
+        const DAI = (await ethers.getContractAt('IERC20', addresses.stablecoins.dai)) as IERC20;
 
         return {
             owner,
@@ -110,6 +119,7 @@ describe('Recapitalization Manager', async () => {
             FXS,
             SDT,
             SPELL,
+            DAI,
         };
     }
 
@@ -140,12 +150,15 @@ describe('Recapitalization Manager', async () => {
             expect(await stakingRewardDistributor.isRewardTokenAdded(addresses.crypto.cvx)).is.true;
             expect(await stakingRewardDistributor.isRewardTokenAdded(addresses.crypto.fxs)).is.true;
             expect(await stakingRewardDistributor.isRewardTokenAdded(addresses.crypto.sdt)).is.true;
+            expect(await stakingRewardDistributor.isRewardTokenAdded(ZUN.address)).is.true;
+
             expect(await stakingRewardDistributor.poolCount()).to.equal(1);
 
             expect(await recapitalizationManager.rewardTokens(0)).to.equal(addresses.crypto.crv);
             expect(await recapitalizationManager.rewardTokens(1)).to.equal(addresses.crypto.cvx);
             expect(await recapitalizationManager.rewardTokens(2)).to.equal(addresses.crypto.fxs);
             expect(await recapitalizationManager.rewardTokens(3)).to.equal(addresses.crypto.sdt);
+            expect(await recapitalizationManager.rewardTokens(4)).to.equal(ZUN.address);
             expect(await recapitalizationManager.zunToken()).to.equal(ZUN.address);
             expect(await recapitalizationManager.stakingRewardDistributor()).to.equal(
                 stakingRewardDistributor.address
@@ -315,7 +328,7 @@ describe('Recapitalization Manager', async () => {
 
         it('Should distribute rewards from recapitalization manager twice', async () => {
             // given
-            const { owner, recapitalizationManager, stakingRewardDistributor, CRV, CVX, FXS, SDT } =
+            const { recapitalizationManager, stakingRewardDistributor, CRV, CVX, FXS, SDT } =
                 await loadFixture(deployFixture);
             // first distribution
             await provideLiquidity(
@@ -433,8 +446,7 @@ describe('Recapitalization Manager', async () => {
     describe('Recapitalize pool by rewards', async () => {
         it('Should recapitalize pool by rewards', async () => {
             // given
-            const { recapitalizationManager, stakingRewardDistributor, CRV, SDT } =
-                await loadFixture(deployFixture);
+            const { recapitalizationManager, CRV, SDT } = await loadFixture(deployFixture);
             // deploy zunUSD
             const { zunUSD, zunUSDController } = await deployZunUSDPoolWithStrategies();
             await zunUSDController.changeRewardCollector(recapitalizationManager.address);
@@ -469,8 +481,6 @@ describe('Recapitalization Manager', async () => {
                 )
             );
 
-            console.log(`${expectedDepositInFeeToken}`);
-
             // when
             const tx = await recapitalizationManager.recapitalizePoolByRewards(
                 sellingCurveRewardManager.address,
@@ -498,6 +508,621 @@ describe('Recapitalization Manager', async () => {
                         .abs()
                         .lte(BigNumber.from('100000000000000'))
                 );
+        });
+    });
+
+    describe('Recapitalize pool by staked zun', async () => {
+        it('Should recapitalize pool by staked zun', async () => {
+            // given
+            const {
+                recapitalizationManager,
+                otherAccount,
+                otherAccount1,
+                stakingRewardDistributor,
+                ZUN,
+                DAI,
+            } = await loadFixture(deployFixture);
+            // deploy zunUSD
+            const { zunUSD } = await deployZunUSDPoolWithStrategies();
+
+            // grant controller role for recapitalization manager
+            await zunUSD.grantRole(await zunUSD.CONTROLLER_ROLE(), recapitalizationManager.address);
+            const tid = 0; // DAI zunUSD pool tokenId
+            const sid = 1; // UsdcCrvUsdStakeDaoCurve strategy
+
+            // prepare sponsor account for StubZunToRewardManager and deploy it for ZUN -> pool depositToken conversion
+            const rewardManagerSponsor = otherAccount1;
+            await provideLiquidity(
+                addresses.stablecoins.dai,
+                DAI_SPONSOR,
+                rewardManagerSponsor.address,
+                parseDAI(10000)
+            );
+            const StubZunToDAITokenManager = await ethers.getContractFactory(
+                'StubZunToDAITokenManager'
+            );
+            const stubZunToDAITokenManager = await StubZunToDAITokenManager.deploy(
+                ZUN.address,
+                rewardManagerSponsor.address
+            );
+            await stubZunToDAITokenManager.deployed();
+
+            // approve stubZunToDAITokenManager to spend rewardManagerSponsor DAI tokens
+            await DAI.connect(rewardManagerSponsor).approve(
+                stubZunToDAITokenManager.address,
+                parseDAI(10000)
+            );
+
+            // deposit zun tokens to reward distributor
+            await ZUN.transfer(otherAccount.address, parseEther('1000'));
+            await ZUN.connect(otherAccount).approve(
+                stakingRewardDistributor.address,
+                parseZUN(1000)
+            );
+            await stakingRewardDistributor.connect(otherAccount).deposit(0, parseZUN(1000));
+
+            // when
+            const tx = await recapitalizationManager.recapitalizePoolByStackedZun(
+                parseZUN(500),
+                stubZunToDAITokenManager.address,
+                zunUSD.address,
+                sid,
+                tid
+            );
+
+            // then
+            await expect(tx)
+                .to.emit(recapitalizationManager, 'RecapitalizedPoolByStackedZun')
+                .withArgs(
+                    parseZUN(500),
+                    stubZunToDAITokenManager.address,
+                    zunUSD.address,
+                    sid,
+                    tid
+                );
+            await expect(tx)
+                .to.emit(stakingRewardDistributor, 'WithdrawnPoolToken')
+                .withArgs(ZUN.address, parseZUN(500));
+            await expect(tx).to.changeTokenBalances(
+                ZUN,
+                [stakingRewardDistributor.address, stubZunToDAITokenManager.address],
+                [parseZUN(500).mul(-1), parseZUN(500)]
+            );
+            // check that transfer in DAI happened to strategy (with 1:1 conversion to ZUN)
+            const strategyAddress = (await zunUSD.strategyInfo(sid)).strategy;
+            await expect(tx)
+                .to.emit(DAI, 'Transfer')
+                .withArgs(zunUSD.address, strategyAddress, parseZUN(500));
+        });
+        it('Should recapitalize pool by staked zun twice and reward distributor has deposits by different users', async () => {
+            // given
+            const {
+                recapitalizationManager,
+                otherAccount,
+                otherAccount1,
+                stakingRewardDistributor,
+                ZUN,
+                DAI,
+            } = await loadFixture(deployFixture);
+            // deploy zunUSD
+            const { zunUSD } = await deployZunUSDPoolWithStrategies();
+
+            // grant controller role for recapitalization manager
+            await zunUSD.grantRole(await zunUSD.CONTROLLER_ROLE(), recapitalizationManager.address);
+            const tid = 0; // DAI zunUSD pool tokenId
+            const sid = 1; // UsdcCrvUsdStakeDaoCurve strategy
+
+            // prepare sponsor account for StubZunToRewardManager and deploy it for ZUN -> pool depositToken conversion
+            const rewardManagerSponsor = otherAccount1;
+            await provideLiquidity(
+                addresses.stablecoins.dai,
+                DAI_SPONSOR,
+                rewardManagerSponsor.address,
+                parseDAI(10000)
+            );
+            const StubZunToDAITokenManager = await ethers.getContractFactory(
+                'StubZunToDAITokenManager'
+            );
+            const stubZunToDAITokenManager = await StubZunToDAITokenManager.deploy(
+                ZUN.address,
+                rewardManagerSponsor.address
+            );
+            await stubZunToDAITokenManager.deployed();
+
+            // approve stubZunToDAITokenManager to spend rewardManagerSponsor DAI tokens
+            await DAI.connect(rewardManagerSponsor).approve(
+                stubZunToDAITokenManager.address,
+                parseDAI(10000)
+            );
+
+            // deposit zun tokens to reward distributor by two different users
+            await ZUN.transfer(otherAccount.address, parseZUN(500));
+            await ZUN.transfer(otherAccount1.address, parseZUN(500));
+            await ZUN.connect(otherAccount).approve(
+                stakingRewardDistributor.address,
+                parseZUN(500)
+            );
+            await ZUN.connect(otherAccount1).approve(
+                stakingRewardDistributor.address,
+                parseZUN(500)
+            );
+            await stakingRewardDistributor.connect(otherAccount).deposit(0, parseZUN(500));
+            await stakingRewardDistributor.connect(otherAccount1).deposit(0, parseZUN(500));
+
+            // make first recapitalization
+            await recapitalizationManager.recapitalizePoolByStackedZun(
+                parseZUN(500),
+                stubZunToDAITokenManager.address,
+                zunUSD.address,
+                sid,
+                tid
+            );
+
+            // when (second recapitalization)
+            const tx = await recapitalizationManager.recapitalizePoolByStackedZun(
+                parseZUN(400),
+                stubZunToDAITokenManager.address,
+                zunUSD.address,
+                sid,
+                tid
+            );
+
+            // then
+            await expect(tx)
+                .to.emit(recapitalizationManager, 'RecapitalizedPoolByStackedZun')
+                .withArgs(
+                    parseZUN(400),
+                    stubZunToDAITokenManager.address,
+                    zunUSD.address,
+                    sid,
+                    tid
+                );
+            await expect(tx)
+                .to.emit(stakingRewardDistributor, 'WithdrawnPoolToken')
+                .withArgs(ZUN.address, parseZUN(400));
+            await expect(tx).to.changeTokenBalances(
+                ZUN,
+                [stakingRewardDistributor.address, stubZunToDAITokenManager.address],
+                [parseZUN(400).mul(-1), parseZUN(400)]
+            );
+            // check that transfer in DAI happened to strategy (with 1:1 conversion to ZUN)
+            const strategyAddress = (await zunUSD.strategyInfo(sid)).strategy;
+            await expect(tx)
+                .to.emit(DAI, 'Transfer')
+                .withArgs(zunUSD.address, strategyAddress, parseZUN(400));
+        });
+        it('Should not recapitalize pool by staked zun if reward distributor doesn`t have enough tokens', async () => {
+            // given
+            const {
+                recapitalizationManager,
+                otherAccount,
+                otherAccount1,
+                stakingRewardDistributor,
+                ZUN,
+                DAI,
+            } = await loadFixture(deployFixture);
+            // deploy zunUSD
+            const { zunUSD } = await deployZunUSDPoolWithStrategies();
+
+            // grant controller role for recapitalization manager
+            await zunUSD.grantRole(await zunUSD.CONTROLLER_ROLE(), recapitalizationManager.address);
+            const tid = 0; // DAI zunUSD pool tokenId
+            const sid = 1; // UsdcCrvUsdStakeDaoCurve strategy
+
+            // prepare sponsor account for StubZunToRewardManager and deploy it for ZUN -> pool depositToken conversion
+            const rewardManagerSponsor = otherAccount1;
+            await provideLiquidity(
+                addresses.stablecoins.dai,
+                DAI_SPONSOR,
+                rewardManagerSponsor.address,
+                parseDAI(10000)
+            );
+            const StubZunToDAITokenManager = await ethers.getContractFactory(
+                'StubZunToDAITokenManager'
+            );
+            const stubZunToDAITokenManager = await StubZunToDAITokenManager.deploy(
+                ZUN.address,
+                rewardManagerSponsor.address
+            );
+            await stubZunToDAITokenManager.deployed();
+
+            // approve stubZunToDAITokenManager to spend rewardManagerSponsor DAI tokens
+            await DAI.connect(rewardManagerSponsor).approve(
+                stubZunToDAITokenManager.address,
+                parseDAI(10000)
+            );
+
+            // deposit zun tokens to reward distributor
+            await ZUN.transfer(otherAccount.address, parseEther('1000'));
+            await ZUN.connect(otherAccount).approve(
+                stakingRewardDistributor.address,
+                parseZUN(1000)
+            );
+            await stakingRewardDistributor.connect(otherAccount).deposit(0, parseZUN(1000));
+
+            // when
+            const tx = recapitalizationManager.recapitalizePoolByStackedZun(
+                parseZUN(2000),
+                stubZunToDAITokenManager.address,
+                zunUSD.address,
+                sid,
+                tid
+            );
+
+            // then
+            await expect(tx).to.revertedWithCustomError(stakingRewardDistributor, 'WrongAmount');
+        });
+    });
+    describe('Restore staked zun by rewards', async () => {
+        it('Should restore staked zun by rewards', async () => {
+            // given
+            const {
+                owner,
+                otherAccount,
+                otherAccount1,
+                DAI,
+                recapitalizationManager,
+                stakingRewardDistributor,
+                ZUN,
+            } = await loadFixture(deployFixture);
+
+            // deploy zunUSD and recapitalize pool by staked zun
+            const { zunUSD } = await deployZunUSDPoolWithStrategies();
+            await zunUSD.grantRole(await zunUSD.CONTROLLER_ROLE(), recapitalizationManager.address);
+            const tid = 0; // DAI zunUSD pool tokenId
+            const sid = 1; // UsdcCrvUsdStakeDaoCurve strategy
+            const rewardManagerSponsor = otherAccount1;
+            await provideLiquidity(
+                addresses.stablecoins.dai,
+                DAI_SPONSOR,
+                rewardManagerSponsor.address,
+                parseDAI(10000)
+            );
+            const StubZunToDAITokenManager = await ethers.getContractFactory(
+                'StubZunToDAITokenManager'
+            );
+            const stubZunToDAITokenManager = await StubZunToDAITokenManager.deploy(
+                ZUN.address,
+                rewardManagerSponsor.address
+            );
+            await stubZunToDAITokenManager.deployed();
+            await DAI.connect(rewardManagerSponsor).approve(
+                stubZunToDAITokenManager.address,
+                parseDAI(10000)
+            );
+            await ZUN.transfer(otherAccount.address, parseEther('1000'));
+            await ZUN.connect(otherAccount).approve(
+                stakingRewardDistributor.address,
+                parseZUN(1000)
+            );
+            await stakingRewardDistributor.connect(otherAccount).deposit(0, parseZUN(1000));
+            const recapitalizationAmount = parseZUN(40);
+            await recapitalizationManager.recapitalizePoolByStackedZun(
+                recapitalizationAmount,
+                stubZunToDAITokenManager.address,
+                zunUSD.address,
+                sid,
+                tid
+            );
+
+            // provide new rewards to recapitalization manager
+            await provideLiquidity(
+                addresses.crypto.crv,
+                CRV_SPONSOR,
+                recapitalizationManager.address,
+                parseEther('10')
+            );
+            await provideLiquidity(
+                addresses.crypto.cvx,
+                CVX_SPONSOR,
+                recapitalizationManager.address,
+                parseEther('10')
+            );
+            await provideLiquidity(
+                addresses.crypto.fxs,
+                FXS_SPONSOR,
+                recapitalizationManager.address,
+                parseEther('10')
+            );
+            await provideLiquidity(
+                addresses.crypto.sdt,
+                SDT_SPONSOR,
+                recapitalizationManager.address,
+                parseEther('10')
+            );
+
+            // deploy StubRewardToZunManager and approve spending from ZUN holder
+            const StubRewardToZunManager = await ethers.getContractFactory(
+                'StubRewardToZunManager'
+            );
+            const zunTokenHolder = owner;
+            const stubRewardToZunManager = await StubRewardToZunManager.deploy(
+                ZUN.address,
+                zunTokenHolder.address
+            );
+            await stubRewardToZunManager.deployed();
+            await ZUN.connect(owner).approve(stubRewardToZunManager.address, parseZUN(40));
+
+            // when
+            const tx = await recapitalizationManager.restoreStakedZunByRewards(
+                stubRewardToZunManager.address
+            );
+
+            // then
+            await expect(tx)
+                .to.emit(recapitalizationManager, 'RestoredStakedZunByRewards')
+                .withArgs(parseZUN(40), stubRewardToZunManager.address, tx.blockNumber);
+            await expect(tx)
+                .to.emit(stakingRewardDistributor, 'ReturnedPoolToken')
+                .withArgs(ZUN.address, parseZUN(40));
+            expect(await stakingRewardDistributor.recapitalizedAmounts(0)).to.equal(0);
+        });
+        it('Should restore staked zun by rewards partially', async () => {
+            // given
+            const {
+                owner,
+                otherAccount,
+                otherAccount1,
+                DAI,
+                recapitalizationManager,
+                stakingRewardDistributor,
+                ZUN,
+            } = await loadFixture(deployFixture);
+
+            // deploy zunUSD and recapitalize pool by staked zun
+            const { zunUSD } = await deployZunUSDPoolWithStrategies();
+            await zunUSD.grantRole(await zunUSD.CONTROLLER_ROLE(), recapitalizationManager.address);
+            const tid = 0; // DAI zunUSD pool tokenId
+            const sid = 1; // UsdcCrvUsdStakeDaoCurve strategy
+            const rewardManagerSponsor = otherAccount1;
+            await provideLiquidity(
+                addresses.stablecoins.dai,
+                DAI_SPONSOR,
+                rewardManagerSponsor.address,
+                parseDAI(10000)
+            );
+            const StubZunToDAITokenManager = await ethers.getContractFactory(
+                'StubZunToDAITokenManager'
+            );
+            const stubZunToDAITokenManager = await StubZunToDAITokenManager.deploy(
+                ZUN.address,
+                rewardManagerSponsor.address
+            );
+            await stubZunToDAITokenManager.deployed();
+            await DAI.connect(rewardManagerSponsor).approve(
+                stubZunToDAITokenManager.address,
+                parseDAI(10000)
+            );
+            await ZUN.transfer(otherAccount.address, parseEther('1000'));
+            await ZUN.connect(otherAccount).approve(
+                stakingRewardDistributor.address,
+                parseZUN(1000)
+            );
+            await stakingRewardDistributor.connect(otherAccount).deposit(0, parseZUN(1000));
+            const recapitalizationAmount = parseZUN(40);
+            await recapitalizationManager.recapitalizePoolByStackedZun(
+                recapitalizationAmount,
+                stubZunToDAITokenManager.address,
+                zunUSD.address,
+                sid,
+                tid
+            );
+
+            // provide new rewards to recapitalization manager
+            await provideLiquidity(
+                addresses.crypto.crv,
+                CRV_SPONSOR,
+                recapitalizationManager.address,
+                parseEther('1')
+            );
+            await provideLiquidity(
+                addresses.crypto.cvx,
+                CVX_SPONSOR,
+                recapitalizationManager.address,
+                parseEther('1')
+            );
+            await provideLiquidity(
+                addresses.crypto.fxs,
+                FXS_SPONSOR,
+                recapitalizationManager.address,
+                parseEther('1')
+            );
+            await provideLiquidity(
+                addresses.crypto.sdt,
+                SDT_SPONSOR,
+                recapitalizationManager.address,
+                parseEther('1')
+            );
+
+            // deploy StubRewardToZunManager and approve spending from ZUN holder
+            const StubRewardToZunManager = await ethers.getContractFactory(
+                'StubRewardToZunManager'
+            );
+            const zunTokenHolder = owner;
+            const stubRewardToZunManager = await StubRewardToZunManager.deploy(
+                ZUN.address,
+                zunTokenHolder.address
+            );
+            await stubRewardToZunManager.deployed();
+            await ZUN.connect(owner).approve(stubRewardToZunManager.address, parseZUN(40));
+
+            // when
+            const tx = await recapitalizationManager.restoreStakedZunByRewards(
+                stubRewardToZunManager.address
+            );
+
+            // then
+            await expect(tx)
+                .to.emit(recapitalizationManager, 'RestoredStakedZunByRewards')
+                .withArgs(parseZUN(4), stubRewardToZunManager.address, tx.blockNumber);
+            await expect(tx)
+                .to.emit(stakingRewardDistributor, 'ReturnedPoolToken')
+                .withArgs(ZUN.address, parseZUN(4));
+            // should be spent during reward distribution
+            expect(await stakingRewardDistributor.recapitalizedAmounts(0)).to.equal(parseZUN(36));
+        });
+        it('Should send remaining ZUN during reward distribution after restoring staked zun by rewards', async () => {
+            // given
+            const {
+                owner,
+                otherAccount,
+                otherAccount1,
+                DAI,
+                recapitalizationManager,
+                stakingRewardDistributor,
+                ZUN,
+            } = await loadFixture(deployFixture);
+
+            // deploy zunUSD and recapitalize pool by staked zun
+            const { zunUSD } = await deployZunUSDPoolWithStrategies();
+            await zunUSD.grantRole(await zunUSD.CONTROLLER_ROLE(), recapitalizationManager.address);
+            const tid = 0; // DAI zunUSD pool tokenId
+            const sid = 1; // UsdcCrvUsdStakeDaoCurve strategy
+            const rewardManagerSponsor = otherAccount1;
+            await provideLiquidity(
+                addresses.stablecoins.dai,
+                DAI_SPONSOR,
+                rewardManagerSponsor.address,
+                parseDAI(10000)
+            );
+            const StubZunToDAITokenManager = await ethers.getContractFactory(
+                'StubZunToDAITokenManager'
+            );
+            const stubZunToDAITokenManager = await StubZunToDAITokenManager.deploy(
+                ZUN.address,
+                rewardManagerSponsor.address
+            );
+            await stubZunToDAITokenManager.deployed();
+            await DAI.connect(rewardManagerSponsor).approve(
+                stubZunToDAITokenManager.address,
+                parseDAI(10000)
+            );
+            await ZUN.transfer(otherAccount.address, parseEther('1000'));
+            await ZUN.connect(otherAccount).approve(
+                stakingRewardDistributor.address,
+                parseZUN(1000)
+            );
+            await stakingRewardDistributor.connect(otherAccount).deposit(0, parseZUN(1000));
+            const recapitalizationAmount = parseZUN(40);
+            await recapitalizationManager.recapitalizePoolByStackedZun(
+                recapitalizationAmount,
+                stubZunToDAITokenManager.address,
+                zunUSD.address,
+                sid,
+                tid
+            );
+
+            // provide new rewards to recapitalization manager
+            await provideLiquidity(
+                addresses.crypto.crv,
+                CRV_SPONSOR,
+                recapitalizationManager.address,
+                parseEther('100')
+            );
+            await provideLiquidity(
+                addresses.crypto.cvx,
+                CVX_SPONSOR,
+                recapitalizationManager.address,
+                parseEther('100')
+            );
+            await provideLiquidity(
+                addresses.crypto.fxs,
+                FXS_SPONSOR,
+                recapitalizationManager.address,
+                parseEther('100')
+            );
+            await provideLiquidity(
+                addresses.crypto.sdt,
+                SDT_SPONSOR,
+                recapitalizationManager.address,
+                parseEther('100')
+            );
+
+            // deploy StubRewardToZunManager and approve spending from ZUN holder
+            const StubRewardToZunManager = await ethers.getContractFactory(
+                'StubRewardToZunManager'
+            );
+            const zunTokenHolder = owner;
+            const stubRewardToZunManager = await StubRewardToZunManager.deploy(
+                ZUN.address,
+                zunTokenHolder.address
+            );
+            await stubRewardToZunManager.deployed();
+            await ZUN.connect(owner).approve(stubRewardToZunManager.address, parseZUN(400));
+
+            // restore staked zun by rewards
+            await recapitalizationManager.restoreStakedZunByRewards(stubRewardToZunManager.address);
+
+            // mine to accumulation period
+            await mine((await recapitalizationManager.accumulationPeriod()).toNumber());
+
+            // when
+            const tx = await recapitalizationManager.distributeRewards();
+
+            // then
+            await expect(tx)
+                .to.emit(recapitalizationManager, 'DistributedRewards')
+                .withArgs(tx.blockNumber);
+            await expect(tx)
+                .to.emit(stakingRewardDistributor, 'RewardPerBlockSet')
+                .withArgs(4, anyUint);
+            await expect(tx).to.changeTokenBalances(
+                ZUN,
+                [recapitalizationManager.address, stakingRewardDistributor.address],
+                [parseZUN(360).mul(-1), parseZUN(360)]
+            );
+            expect(await ZUN.balanceOf(recapitalizationManager.address)).to.equal(0);
+        });
+    });
+
+    describe('Withdraw stuck token', async () => {
+        it('Should withdraw stuck token', async () => {
+            // given
+            const { owner, recapitalizationManager, CRV } = await loadFixture(deployFixture);
+            // provide new rewards to recapitalization manager
+            await provideLiquidity(
+                addresses.crypto.crv,
+                CRV_SPONSOR,
+                recapitalizationManager.address,
+                parseEther('100')
+            );
+
+            // when
+            const tx = await recapitalizationManager.withdrawStuckToken(addresses.crypto.crv);
+
+            // then
+            await expect(tx)
+                .to.emit(recapitalizationManager, 'WithdrawnStuckToken')
+                .withArgs(addresses.crypto.crv);
+            await expect(tx).to.changeTokenBalances(
+                CRV,
+                [recapitalizationManager.address, owner.address],
+                [parseEther('100').mul(-1), parseEther('100')]
+            );
+        });
+        it('Should not withdraw stuck token by not the ADMIN', async () => {
+            // given
+            const { otherAccount, recapitalizationManager, CRV } = await loadFixture(deployFixture);
+            // provide new rewards to recapitalization manager
+            await provideLiquidity(
+                addresses.crypto.crv,
+                CRV_SPONSOR,
+                recapitalizationManager.address,
+                parseEther('100')
+            );
+
+            // when
+            const tx = recapitalizationManager
+                .connect(otherAccount)
+                .withdrawStuckToken(addresses.crypto.crv);
+
+            // then
+            await expect(tx)
+                .to.revertedWithCustomError(
+                    recapitalizationManager,
+                    'AccessControlUnauthorizedAccount'
+                )
+                .withArgs(otherAccount.address, await recapitalizationManager.DEFAULT_ADMIN_ROLE());
         });
     });
 });

--- a/test/unit/RecapitalizationManager.t.ts
+++ b/test/unit/RecapitalizationManager.t.ts
@@ -250,7 +250,7 @@ describe('RecapitalizationManager', () => {
 
         await recapitalizationManager
             .connect(admin)
-            .capitalizeStakedZunByRewards(rewardManager.address);
+            .restoreStakedZunByRewards(rewardManager.address);
 
         stakingRewardDistributor.returnPoolToken
             .atCall(0)


### PR DESCRIPTION
- [x] rename `capitalizeStakedZunByRewards` to `restoreStakedZunByRewards` in `RecapitalizationManager`
- [x] add `withdrawStuckToken` for `RecapitalizationManager`
- [x] add `WithdrawnPoolToken` and `ReturnedPoolToken` events to `StakingRewardDistributor`
- [x] add stub reward managers for testing purposes
- [x] tests for `recapitalizePoolByStackedZun` and `restoreStakedZunByRewards` in `RecapitalizationManager`
- [x] lint fix